### PR TITLE
added scaling_not_by_cap config value custom for ggft

### DIFF
--- a/site-config.js
+++ b/site-config.js
@@ -84,5 +84,5 @@ var site_config = {
     sqrt: true, // need this to trigger the square root interpolation circle asset sizing logic
     geometries: ['Point'],
 
-    scaling_not_by_cap: false, // for gas finance where we used the unit capacity status functionality but 'Capacity' is hardcoded in for single unit projects and the value is not capacity but finance info here. displayDetails() in stie.js is where this is going to be used.
+    scale_by_capacity: true, // for gas finance where we used the unit capacity status functionality but 'Capacity' is hardcoded in for single unit projects and the value is not capacity but finance info here. displayDetails() in stie.js is where this is going to be used.
 };

--- a/site-config.js
+++ b/site-config.js
@@ -81,6 +81,8 @@ var site_config = {
     multiCountry: false,
 
     hitArea: 5, 
-    sqrt: true,
-    geometries: ['Point']
+    sqrt: true, // need this to trigger the square root interpolation circle asset sizing logic
+    geometries: ['Point'],
+
+    scaling_not_by_cap: false, // for gas finance where we used the unit capacity status functionality but 'Capacity' is hardcoded in for single unit projects and the value is not capacity but finance info here. displayDetails() in stie.js is where this is going to be used.
 };

--- a/src/site.js
+++ b/src/site.js
@@ -1599,7 +1599,7 @@ function displayDetails(features) {
 
             // if ggft gas finance then we want to override this always since the project level financing info is already printed 
             // and this else only executes if there is just one unit for the project so it'd be redundant and the word 'Capacity' is hardcoded in this feature and makes no sense for ggft
-            if (config.scaling_not_by_cap==true) {
+            if (config.scale_by_capacity==false) {
                 console.log('Skipping single unit project capacity for ggft since it is finance info and is covered already, but displaying status info since it is useful and not redundant.')
                 // we do not want the capacity but we do want status since that is relevant for single unit ggft projects
                 // since we know for ggft the status is a color field we do not need the extra logic seen below with "config.color.field != config.statusDisplayField"

--- a/src/site.js
+++ b/src/site.js
@@ -1458,11 +1458,7 @@ function displayDetails(features) {
     // Build capacity summary by unit
     // Make sure capacity and parenthese get removed if there is only one feature
     if (capacityLabel != ''){
-        // PICK THIS UP TOMORROW
-        // if (config.scaling_not_by_cap===true && capacityLabel2!=''){
-        //     //want to also show capacity value by status / unit ... so will need to figure out units of measurement shit won't work I think... will need two capacityLabels
-        //     console.log('scaling not by capacity!')
-        // }
+
         if (features.length > 1) { 
         let filterIndex = 0;
             for (const[index, filter] of config.filters.entries()) {
@@ -1600,43 +1596,46 @@ function displayDetails(features) {
         }
         // else when there is only one feature or one unit per project in the popup modal
         else {
-            // console.log('This is capacity:')
-            // console.log(features[0].properties[config.capacityDisplayField])
-            // console.log(features[0].properties[config.capacityDisplayField]) // Himeji-Okayama Gas Pipeline
 
-            capacityFloat = Number(features[0].properties[config.capacityDisplayField])
-            // console.log(capacityFloat) // Himeji-Okayama Gas Pipeline
-
-            // console.log(typeof capacityFloat)
-            // if capacity is a string and when you convert with Number it is 0 then we can say it is NA or Not found
-            if (features[0].properties[config.capacityDisplayField] === ''){
-                    capacityFloatandLabel = 'Not found or N/A'
-            }
-
-            // if it is not a string then we are good ...  
-            else { 
-                // console.log(capacityFloat) // Himeji-Okayama Gas Pipeline
-                // try Number() instead of parseFloat()
-                capacityFloatandLabel = parseFloat(capacityFloat).toFixed(2).replace(/\.?0+$/, '') + ' ' + capacityLabel
-                // console.log(capacityFloatandLabel)
-            }
-            // this handles capacity adjustment for solo projects where it looks redundant to have Capacity written out twice
-            // Remove 'Capacity' prefix and parentheses from capacityLabel TODO look into a better way to handle, issue if capacity is nan or undefined like intentionally is for GOGET
-            // capacityLabel = capacityLabel.replace(/^Capacity\s*/i, '').replace(/[()]/g, '');
-
-            // and it allows status outside of the summary table to have the colored dot when status is the highest filter section
-            if (config.color.field != config.statusDisplayField){
-                // for filter field in filter, if primary = True then take field name "type" in intg and use it to find the color dictionary in the colors dict above
-                // and then display the projects type field with the appropriate color based on the value and the dictionary
-                detail_text += '<span class="fw-bold text-capitalize">Status</span>: ' +
-                '<span class="text-capitalize">' + features[0].properties[config.statusDisplayField] + '</span><br/>';
-                detail_text += '<span class="fw-bold text-capitalize">Capacity</span>: ' + capacityFloatandLabel;
+            // if ggft gas finance then we want to override this always since the project level financing info is already printed 
+            // and this else only executes if there is just one unit for the project so it'd be redundant and the word 'Capacity' is hardcoded in this feature and makes no sense for ggft
+            if (config.scaling_not_by_cap==true) {
+                console.log('Skipping single unit project capacity for ggft since it is finance info and is covered already.')
             }
             else {
-                detail_text += '<span class="fw-bold text-capitalize">Status</span>: ' +
-                    '<span class="legend-dot" style="background-color:' + config.color.values[ features[0].properties[config.statusDisplayField] ] + '"></span><span class="text-capitalize">' + features[0].properties[config.statusDisplayField] + '</span><br/>';
-                detail_text += '<span class="fw-bold text-capitalize">Capacity</span>: ' + capacityFloatandLabel;
-            }
+
+                capacityFloat = Number(features[0].properties[config.capacityDisplayField])
+
+                // if capacity is a string and when you convert with Number it is 0 then we can say it is NA or Not found
+                if (features[0].properties[config.capacityDisplayField] === ''){
+                        capacityFloatandLabel = 'Not found or N/A'
+                }
+
+                // if it is not a string then we are good ...  
+                else { 
+                    // console.log(capacityFloat) // Himeji-Okayama Gas Pipeline
+                    // try Number() instead of parseFloat()
+                    capacityFloatandLabel = parseFloat(capacityFloat).toFixed(2).replace(/\.?0+$/, '') + ' ' + capacityLabel
+                    // console.log(capacityFloatandLabel)
+                }
+                // this handles capacity adjustment for solo projects where it looks redundant to have Capacity written out twice
+                // Remove 'Capacity' prefix and parentheses from capacityLabel TODO look into a better way to handle, issue if capacity is nan or undefined like intentionally is for GOGET
+                // capacityLabel = capacityLabel.replace(/^Capacity\s*/i, '').replace(/[()]/g, '');
+
+                // and it allows status outside of the summary table to have the colored dot when status is the highest filter section
+                if (config.color.field != config.statusDisplayField){
+                    // for filter field in filter, if primary = True then take field name "type" in intg and use it to find the color dictionary in the colors dict above
+                    // and then display the projects type field with the appropriate color based on the value and the dictionary
+                    detail_text += '<span class="fw-bold text-capitalize">Status</span>: ' +
+                    '<span class="text-capitalize">' + features[0].properties[config.statusDisplayField] + '</span><br/>';
+                    detail_text += '<span class="fw-bold text-capitalize">Capacity</span>: ' + capacityFloatandLabel;
+                }
+                else {
+                    detail_text += '<span class="fw-bold text-capitalize">Status</span>: ' +
+                        '<span class="legend-dot" style="background-color:' + config.color.values[ features[0].properties[config.statusDisplayField] ] + '"></span><span class="text-capitalize">' + features[0].properties[config.statusDisplayField] + '</span><br/>';
+                    detail_text += '<span class="fw-bold text-capitalize">Capacity</span>: ' + capacityFloatandLabel;
+                }
+                }
             }
     }
     // This is where you remove the colored circle primary = true

--- a/src/site.js
+++ b/src/site.js
@@ -1600,7 +1600,12 @@ function displayDetails(features) {
             // if ggft gas finance then we want to override this always since the project level financing info is already printed 
             // and this else only executes if there is just one unit for the project so it'd be redundant and the word 'Capacity' is hardcoded in this feature and makes no sense for ggft
             if (config.scaling_not_by_cap==true) {
-                console.log('Skipping single unit project capacity for ggft since it is finance info and is covered already.')
+                console.log('Skipping single unit project capacity for ggft since it is finance info and is covered already, but displaying status info since it is useful and not redundant.')
+                // we do not want the capacity but we do want status since that is relevant for single unit ggft projects
+                // since we know for ggft the status is a color field we do not need the extra logic seen below with "config.color.field != config.statusDisplayField"
+                detail_text += '<span class="fw-bold text-capitalize">Status</span>: ' +
+                '<span class="legend-dot" style="background-color:' + config.color.values[ features[0].properties[config.statusDisplayField] ] + '"></span><span class="text-capitalize">' + features[0].properties[config.statusDisplayField] + '</span><br/>';
+
             }
             else {
 

--- a/trackers/ggft/config.js
+++ b/trackers/ggft/config.js
@@ -69,9 +69,9 @@ var config = {
     // multiCountry: true,
     capacityDisplayField: 'fin-by-transac', // need this since it'll sum .. need to make float, this is what gets used in site.js for all details. 
     
-    // HOLD TODO not sure if they want this this badly ... will make site.js more complicated
-    // scaling_not_by_cap: true,
+    scaling_not_by_cap: true, //originally created this to allow for both finance data and capacity data by unit in the popup, but should be useful to fix the issue when there is one unit and we do not want capacity (in this case financing info) to show up because project level financing is already shown when available
 
+    // if they want to include capacity values by unit in the popup would need this, but they don't say it's a priority so comment out
     // capacityLabel2:  {       
     //     field: 'infra-filter',
     //     values: {
@@ -83,8 +83,8 @@ var config = {
     // 'project-fin-scaling','fin-by-transac', 
     // 'debug capacityField project-fin-scaling','debug capacityDisplayField fin-by-transac',
     tableHeaders: {
-        values: ['fin', 'name', 'debtequityelse','owner', 'parent', 'importexport','opstatus', 'areas', 'startyear', 'capacitymw', 'capacitymtpa'],
-        labels: ['Financier', 'Project Name', 'Financing Type','Owner', 'Parent','Terminal Facility Type', 'Operational Status','Country/Area(s)','Start year', 'Capacity (MW)', 'Capacity (MTPA)'],
+        values: ['fin', 'name', 'unitname', 'debtequityelse','owner', 'parent', 'importexport','opstatus', 'areas', 'startyear', 'capacitymw', 'capacitymtpa'],
+        labels: ['Financier', 'Project Name', 'Unit Name','Financing Type','Owner', 'Parent','Terminal Facility Type', 'Operational Status','Country/Area(s)','Start year', 'Capacity (MW)', 'Capacity (MTPA)'],
         clickColumns: ['name'],
         rightAlign: ['startyear',], 
         removeLastComma: ['areas'], 
@@ -100,7 +100,7 @@ var config = {
     },
     detailView: {
         'name': {'display': 'heading'},
-        'unitname': {'label': 'Unit Name'},
+        // 'unitname': {'label': 'Unit Name'},
         'debt-project-financing': {'label': 'Debt Project Financing ($ million)'},
         'equity-project-financing': {'label': 'Equity Project Financing ($ million)'},
         // 'debtequityelse': {'label': 'Financing Type'},

--- a/trackers/ggft/config.js
+++ b/trackers/ggft/config.js
@@ -69,7 +69,7 @@ var config = {
     // multiCountry: true,
     capacityDisplayField: 'fin-by-transac', // need this since it'll sum .. need to make float, this is what gets used in site.js for all details. 
     
-    scaling_not_by_cap: true, //originally created this to allow for both finance data and capacity data by unit in the popup, but should be useful to fix the issue when there is one unit and we do not want capacity (in this case financing info) to show up because project level financing is already shown when available
+    scale_by_capacity: false, //originally created this to allow for both finance data and capacity data by unit in the popup, but should be useful to fix the issue when there is one unit and we do not want capacity (in this case financing info) to show up because project level financing is already shown when available
 
     // if they want to include capacity values by unit in the popup would need this, but they don't say it's a priority so comment out
     // capacityLabel2:  {       


### PR DESCRIPTION
Mainly added a config value for ggft so that when there is a single unit project the hardcoded "Capacity" doesn't get displayed in the details popup with this tracker's "capacityField" value which happens to be not a capacity value but a financing value. 

We could not use the override of making "capacityLabel" in the tracker's config.js file equal to " " because ggft _does_
 want to use the functionality created for multi unit projects that have units of varying statuses and capacity values, for their multi unit projects. Instead of operating status and capacity value, for ggft the unit's financing status and financing value is displayed. 

I also cleaned up comments and moved unit name from details popup to table view.