### PR TITLE
updated csv file name for gipt map for solar and wind release

### DIFF
--- a/trackers/integrated/config.js
+++ b/trackers/integrated/config.js
@@ -1,5 +1,5 @@
 var config = {
-    csv: 'https://publicgemdata.nyc3.cdn.digitaloceanspaces.com/Integrated/2026-02/gipt-data-2026-02-03.csv',
+    csv: 'https://publicgemdata.nyc3.cdn.digitaloceanspaces.com/Integrated/2026-02/gipt-data-2026-02-11.csv',
 
     tiles: [
         // 'https://gem.dev.c10e.org/2024-03-12/{z}/{x}/{y}.pbf'


### PR DESCRIPTION
@hannahthehowell  just confirming I'm merging an the update that only touches the config file. The tile file path line did not need to be updated since the file path only goes to month-level. As you see in the screenshot below the tile data was just updated: 

<img width="1364" height="448" alt="Screenshot 2026-02-11 at 1 05 43 PM" src="https://github.com/user-attachments/assets/0b65da48-d1ea-48be-b6e1-2e8bc147a359" />
